### PR TITLE
add css for range slider, use range slider in noteSettings

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,6 +6,7 @@
 	"version": "0.1.4",
 	"minimumCoreVersion": "0.6.6",
 	"compatibleCoreVersion": "0.7.5",
+	"styles": ["styles.css"],
 	"scripts": [
 		"pin-fixer.js"
 	],

--- a/noteSettings.html
+++ b/noteSettings.html
@@ -1,13 +1,25 @@
 <hr>
 <h3 class="form-header"><i class="fas fa-bookmark"></i> {{ localize "pinfix.title" }}</h3>
 <p class="notes">{{ localize "pinfix.notes.description" }}</p>
+
 <div class="form-group">
 	<label>{{ localize "pinfix.notes.minZoomLevel.name" }}</label>
-	<input type="text" name="flags.pinfix.minZoomLevel" data-dtype="Number" value="{{minZoomLevel}}">
+	<div class="range-slider-with-icons">
+		<i class="fas fa-search-minus"></i>
+		<input type="range" name="flags.pinfix.minZoomLevel" data-dtype="Number" value="{{minZoomLevel}}" max="3" min="0.1" step="0.1">
+		<span class="range-value">{{minZoomLevel}}</span>
+		<i class="fas fa-search-plus"></i>
+	</div>
 	<p class="notes">{{ localize "pinfix.notes.minZoomLevel.desc" }}</p>
 </div>
+
 <div class="form-group">
 	<label>{{ localize "pinfix.notes.maxZoomLevel.name" }}</label>
-	<input type="text" name="flags.pinfix.maxZoomLevel" data-dtype="Number" value="{{maxZoomLevel}}">
+	<div class="range-slider-with-icons">
+		<i class="fas fa-search-minus"></i>
+		<input type="range" name="flags.pinfix.maxZoomLevel" data-dtype="Number" value="{{maxZoomLevel}}" min="0.1" max="3" step="0.1">
+		<span class="range-value">{{maxZoomLevel}}</span>
+		<i class="fas fa-search-plus"></i>
+	</div>
 	<p class="notes">{{ localize "pinfix.notes.maxZoomLevel.desc" }}</p>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,14 @@
+.range-slider-with-icons {
+  display: flex;
+  align-items: center;
+}
+
+.range-slider-with-icons input {
+  flex: 3;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}
+
+.range-slider-with-icons .range-value {
+  order: 4;
+}


### PR DESCRIPTION
- Range Slider + Icons makes what these inputs represent simpler to intuit
- Have to do a little flex `order` stuff to get the icons to not ruin the default foundry range slider look